### PR TITLE
Added hadolint to lint our docker images

### DIFF
--- a/.github/workflows/docker-lint.yml
+++ b/.github/workflows/docker-lint.yml
@@ -1,0 +1,18 @@
+name: hadolint
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  docker-linting:
+    name: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: hadolint
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,10 @@ WORKDIR /
 ENV GITLAB_ACCESS_TOKEN=GITLAB_ACCESS_TOKEN
 
 # install necessary packages
-# hadolint ignore=DL3008
 RUN set -eux; \
   apt-get update && \
   apt-get install -y --no-install-recommends \
-  python3 \
+  python3=3.7.3-1 \
   python3-pip=18.1-5 \
   python3-setuptools=40.8.0-1 && \
   apt-get clean all && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ ENV GITLAB_ACCESS_TOKEN=GITLAB_ACCESS_TOKEN
 # install necessary packages
 RUN set -eux; \
   apt-get update && \
-  apt-get install -y \
-  python3 \
-  python3-pip && \
+  apt-get install -y --no-install-recommends \
+  python3=3.10.6 \
+  python3-pip=22.0.2 && \
   apt-get clean all && \
   rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,11 @@ WORKDIR /
 ENV GITLAB_ACCESS_TOKEN=GITLAB_ACCESS_TOKEN
 
 # install necessary packages
+# hadolint ignore=DL3008
 RUN set -eux; \
   apt-get update && \
   apt-get install -y --no-install-recommends \
-  python3.7 \
+  python3 \
   python3-pip=18.1-5 \
   python3-setuptools=40.8.0-1 && \
   apt-get clean all && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,23 @@
 # use the official kics image as basis image
 FROM checkmarx/kics:v1.6.13-debian
 
+WORKDIR /
+
 ENV GITLAB_ACCESS_TOKEN=GITLAB_ACCESS_TOKEN
 
 # install necessary packages
 RUN set -eux; \
   apt-get update && \
   apt-get install -y --no-install-recommends \
-  python3=3.10.6 \
-  python3-pip=22.0.2 && \
+  python3.7 \
+  python3-pip=18.1-5 \
+  python3-setuptools=40.8.0-1 && \
   apt-get clean all && \
   rm -rf /var/lib/apt/lists/*
 
 # install python packages from our requirements.txt
 COPY requirements.txt .
-RUN pip3 install -r requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
 
 # copy and execute repo_scanner.py
 COPY repo_scanner.py .


### PR DESCRIPTION
I added a GitHub Action that executes Hadolint whenever there is a pull request against or main branch. On top Renovate needs tests to run before it can automerge the pull requests created by renovate (https://docs.renovatebot.com/key-concepts/automerge/#absence-of-tests)