### PR TITLE
fix - repair failing build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,21 +5,22 @@ WORKDIR /
 
 ENV GITLAB_ACCESS_TOKEN=GITLAB_ACCESS_TOKEN
 
-# install necessary packages
+# copy the requirements.txt, repo_scanner.py, and templates directory to the container
+COPY requirements.txt .
+COPY repo_scanner.py .
+COPY templates ./templates/.
+
+# install python3, python3-venv, and the required python packages in a virtual environment
 RUN set -eux; \
   apt-get update && \
   apt-get install -y --no-install-recommends \
-  python3=3.7.3-1 \
-  python3-pip=18.1-5 \
-  python3-setuptools=40.8.0-1 && \
+  python3=3.13.5-1 \
+  python3-venv=3.13.5-1 && \
   apt-get clean all && \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/* && \
+  python3 -m venv .venv && \
+  . .venv/bin/activate && \
+  pip install --no-cache-dir -r requirements.txt
 
-# install python packages from our requirements.txt
-COPY requirements.txt .
-RUN pip3 install --no-cache-dir -r requirements.txt
-
-# copy and execute repo_scanner.py
-COPY repo_scanner.py .
-COPY templates ./templates/.
-ENTRYPOINT ["python3", "repo_scanner.py"]
+# set the entrypoint to run the repo_scanner.py script when the container starts
+ENTRYPOINT ["/.venv/bin/python3", "repo_scanner.py"]


### PR DESCRIPTION
Build failed with the following error: 

```
 > [2/7] RUN set -eux;   apt-get update &&   apt-get install -y --no-install-recommends   python3=3.7.3-1   python3-pip=18.1-5   python3-setuptools=40.8.0-1 &&   apt-get clean all &&   rm -rf /var/lib/apt/lists/*:
2.854 However the following packages replace it:
2.854   python3-pkg-resources
2.854 
2.854 Package python3-pip is not available, but is referred to by another package.
2.854 This may mean that the package is missing, has been obsoleted, or
2.854 is only available from another source
2.854 
2.856 E: Version '3.7.3-1' for 'python3' was not found
2.856 E: Version '18.1-5' for 'python3-pip' was not found
2.856 E: Version '40.8.0-1' for 'python3-setuptools' was not found
------
 1 warning found (use docker --debug to expand):
 - SecretsUsedInArgOrEnv: Do not use ARG or ENV instructions for sensitive data (ENV "GITLAB_ACCESS_TOKEN") (line 6)
Dockerfile:9
--------------------
   8 |     # install necessary packages
   9 | >>> RUN set -eux; \
  10 | >>>   apt-get update && \
  11 | >>>   apt-get install -y --no-install-recommends \
  12 | >>>   python3=3.7.3-1 \
  13 | >>>   python3-pip=18.1-5 \
  14 | >>>   python3-setuptools=40.8.0-1 && \
  15 | >>>   apt-get clean all && \
  16 | >>>   rm -rf /var/lib/apt/lists/*
  17 |     
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c set -eux;   apt-get update &&   apt-get install -y --no-install-recommends   python3=3.7.3-1   python3-pip=18.1-5   python3-setuptools=40.8.0-1 &&   apt-get clean all &&   rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100
```